### PR TITLE
Add wrapping parens for nested binary expressions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1472,6 +1472,7 @@ impl<T: Write> Writer<T> {
             | Expr::Conditional(_)
             | Expr::Logical(_) 
             | Expr::Func(_)
+            | Expr::Binary(_)
             | Expr::ArrowFunc(_) => self.write_wrapped_expr(side),
             _ => self.write_expr(side),
         }


### PR DESCRIPTION
This is a kinda fast-fix for #7.

Maybe it's better to code understanding of how precedence work to drop parenthesis when possible.

Discussion required :)