### PR TITLE
remove resast::AsConcrete

### DIFF
--- a/examples/snippet_writer.rs
+++ b/examples/snippet_writer.rs
@@ -2,7 +2,6 @@ use ressa::{Parser};
 use resw::Writer;
 use std::fs::{read_to_string, File};
 use pretty_env_logger::init;
-use resast::ref_tree::AsConcrete;
 
 pub fn main() {
     ::std::env::set_var("RUST_LOG", "resw=trace");
@@ -22,6 +21,6 @@ pub fn main() {
 
     for part in p {
         let part = part.expect("Failed to get part");
-        w.write_part(&part.as_concrete()).expect(&format!("Failed to write {:?}", part));
+        w.write_part(&part).expect(&format!("Failed to write {:?}", part));
     }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -103,7 +103,7 @@ fn double_round_trip(js: &str, module: bool) -> (String, Option<String>) {
                 break;
             },
         };
-        first_writer.write_part(&part.as_concrete()).expect("Failed to write part");
+        first_writer.write_part(&part).expect("Failed to write part");
     }
     let first_pass = first_write.get_string().expect("Invalid utf-8 written to first write");
     let second_parser = Parser::builder().module(module).js(first_pass.as_str()).build().expect("Failed to create second parser");
@@ -122,7 +122,7 @@ fn double_round_trip(js: &str, module: bool) -> (String, Option<String>) {
                 return (first_pass, second_pass)
             },
         };
-        second_writer.write_part(&part.as_concrete()).expect("failed to write part");
+        second_writer.write_part(&part).expect("failed to write part");
     }
     let second_pass = second_write.get_string().expect("Invalid utf-8 written to second write");
     (first_pass, Some(second_pass))

--- a/tests/spider_monkey.rs
+++ b/tests/spider_monkey.rs
@@ -100,7 +100,7 @@ fn around_once(js: &str) -> Result<String, Error> {
     let mut writer = Writer::new(out.generate_child());
     for part in Parser::new(&js)? {
         let part = part?;
-        writer.write_part(&part.as_concrete()).expect("Failed to write part");
+        writer.write_part(&part).expect("Failed to write part");
     }
     Ok(out.get_string().expect("invalid utf8 written to write_string"))
 }


### PR DESCRIPTION
This fixes a bug that is causing the the tests/examples to fail type checking. 